### PR TITLE
Wire frasermolyneux-copilot MCP server (v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,3 +44,9 @@ Legacy Windows Forms ClickOnce client that discovers local Call of Duty 2/4/WaW 
 - Logging via log4net; config at `DemoManager.App/log4net.config`
 - Be cautious editing Huffman/bit-level parsing logic — small changes can break demo decoding
 - Keep changes minimal; this is a maintenance-mode application
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup .NET
@@ -40,3 +41,14 @@ jobs:
             dotnet-version: |
               9.0.x
               10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo is wired to the shared `frasermolyneux-copilot` MCP server (org conventions catalog). The GitHub Copilot coding agent loads it via `.github/copilot/mcp_config.json`; `copilot-setup-steps.yml` checks out `frasermolyneux/.github-copilot` (pinned to `v0.1.0`) and builds the server (`npm ci && npm run build` in `.github-copilot/mcp-server`). For local clients (VS Code `.vscode/mcp.json`, Claude Desktop, Copilot CLI) and the full tool surface, see [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/main/mcp-server/README.md).
+


### PR DESCRIPTION
Wires this repo to the shared `frasermolyneux-copilot` MCP catalog server so the GitHub Copilot coding agent (and other MCP-capable clients) can query org conventions, instructions, prompts and agents at runtime instead of relying solely on file-load. Mirrors the template already merged to `portal-core`, pinned to tag `v0.1.0` on `frasermolyneux/.github-copilot`.

## Changes

- `.github/workflows/copilot-setup-steps.yml` — pin the existing shared `.github-copilot` checkout to `refs/tags/v0.1.0` (it was previously unpinned), then add `actions/setup-node@v6` (Node 20.x) and a `Build MCP server` step running `npm ci && npm run build` in `.github-copilot/mcp-server`.
- `.github/copilot/mcp_config.json` — new file declaring the local stdio MCP server `frasermolyneux-copilot` for the coding agent, pointing at the built `dist/index.js` with `GH_COPILOT_CONTENT_ROOT=.github-copilot`.
- `.github/copilot-instructions.md` — append the canonical `## Org conventions via MCP (when available)` bootstrap section (source-of-truth: `metadata.copilot-instructions` in `frasermolyneux/.github-copilot`, content SHA256 prefix `DDAC8AA449794730` with CRLF).
- `README.md` — short `## Local dev: MCP wire-up` pointer to `.github-copilot/mcp-server/README.md`.

## Notes for reviewers

- `AGENTS.md` does not exist in this repo, so the parallel byte-identical snippet was not written there. Bootstrapping `AGENTS.md` is owned by the separate `update-project-metadata` agent and is flagged as a follow-up.
- Pinning the existing shared-config checkout is a one-line `with:` change (no new step) to avoid a duplicate checkout into the same path. The previous unpinned state may exist in other consumer repos in this org.
- This is a maintenance-mode .NET Framework 4.8 WinForms repo; no application code is touched.